### PR TITLE
Change name

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Integration for Fresh Intellivent Sky (Bluetooth LE)",
-    "render_readme": true
-  }
+  "name": "Fresh Intellivent Sky Integration (BLE)",
+  "render_readme": true
+}


### PR DESCRIPTION
Today the name is very long and don't look good in HACS:

![FIS_HACS_Card](https://user-images.githubusercontent.com/4216986/209221449-e1b4299d-50fb-4603-a824-2133a04d9757.jpg)

I suggest we shorten the name to make it look better on HACS-card.