### PR TITLE
Fix deprecated code

### DIFF
--- a/custom_components/fresh_intellivent_sky/config_flow.py
+++ b/custom_components/fresh_intellivent_sky/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from bleak import BleakError
 from pyfreshintellivent import FreshIntelliVent
@@ -216,7 +216,7 @@ class FreshIntelliventSkyOptionsFlowHandler(OptionsFlow):  # type: ignore[misc]
         """Manage the options."""
         if user_input is not None:
             return cast(
-                Dict[str, Any], self.async_create_entry(title="", data=user_input)
+                dict[str, Any], self.async_create_entry(title="", data=user_input)
             )
 
         schema: dict[Any, Any] = {
@@ -230,6 +230,6 @@ class FreshIntelliventSkyOptionsFlowHandler(OptionsFlow):  # type: ignore[misc]
         }
 
         return cast(
-            Dict[str, Any],
+            dict[str, Any],
             self.async_show_form(step_id="init", data_schema=vol.Schema(schema)),
         )

--- a/custom_components/fresh_intellivent_sky/number.py
+++ b/custom_components/fresh_intellivent_sky/number.py
@@ -7,7 +7,7 @@ from pyfreshintellivent import FreshIntelliVent
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import REVOLUTIONS_PER_MINUTE, TIME_MINUTES
+from homeassistant.const import REVOLUTIONS_PER_MINUTE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -96,7 +96,7 @@ async def async_setup_entry(
                     native_min_value=5,
                     native_max_value=120,
                     native_step=1,
-                    native_unit_of_measurement=TIME_MINUTES,
+                    native_unit_of_measurement=UnitOfTime.MINUTES,
                 ),
                 entity_category=EntityCategory.CONFIG,
                 keys=["airing", "minutes"],
@@ -124,7 +124,7 @@ async def async_setup_entry(
                     native_min_value=1,
                     native_max_value=60,
                     native_step=1,
-                    native_unit_of_measurement=TIME_MINUTES,
+                    native_unit_of_measurement=UnitOfTime.MINUTES,
                 ),
                 entity_category=EntityCategory.CONFIG,
                 keys=["timer", "minutes"],
@@ -138,7 +138,7 @@ async def async_setup_entry(
                     native_min_value=1,
                     native_max_value=60,
                     native_step=4,
-                    native_unit_of_measurement=TIME_MINUTES,
+                    native_unit_of_measurement=UnitOfTime.MINUTES,
                 ),
                 entity_category=EntityCategory.CONFIG,
                 keys=["timer", "delay", "minutes"],


### PR DESCRIPTION
Now when I have the DEV CONTAINER for Home Assistant development setup I got some deprecation warnings.
I did read about the change and found out that in Python >=3.9 dict is as flexible as typing.Dict and can be used.

I also found that some enum's should be used now.

But, I am a newbie, please look and comment if I miss something! 