### PR TITLE
WIP: Implement new config flow

### DIFF
--- a/custom_components/fresh_intellivent_sky/__init__.py
+++ b/custom_components/fresh_intellivent_sky/__init__.py
@@ -77,12 +77,12 @@ async def async_setup_entry(
     async def _async_update_method():
         """Get data from Fresh Intellivent Sky."""
         ble_device = bluetooth.async_ble_device_from_address(hass, address)
-        client = FreshIntelliVent()
+        client = FreshIntelliVent(ble_device=ble_device)
 
         error = None
 
         try:
-            await client.connect(ble_device, TIMEOUT)
+            await client.connect(TIMEOUT)
             if auth_key is not None:
                 await client.authenticate(authentication_code=auth_key)
             await client.fetch_sensor_data()

--- a/custom_components/fresh_intellivent_sky/config_flow.py
+++ b/custom_components/fresh_intellivent_sky/config_flow.py
@@ -18,8 +18,8 @@ from pyfreshintellivent import FreshIntelliVent
 from pyfreshintellivent.helpers import validated_authentication_code
 from voluptuous.validators import All, Range
 
-from .const import (CONF_AUTH_KEY, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-                    DOMAIN, NAME)
+from .const import (CONF_AUTH_KEY, CONF_AUTH_METHOD, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
+                    DOMAIN, NAME, AUTH_MANUAL, AUTH_FETCH, NO_AUTH)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,12 +61,11 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
         if ble_device is None:
             raise FreshIntelliventSkyDeviceUpdateError("No ble_device")
 
-        client = FreshIntelliVent()
-
+        client = FreshIntelliVent(ble_device=ble_device)
         error = None
 
         try:
-            await client.connect(ble_device, 30.0)
+            await client.connect(timeout=30.0)
             await client.fetch_device_information()
         except BleakError as err:
             _LOGGER.error(
@@ -120,7 +119,7 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
                 description_placeholders=self.context["title_placeholders"],
             )
 
-        return await self.async_step_auth()
+        return await self.async_step_auth_method()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -137,7 +136,7 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
             }
             self._discovered_device = discovery
 
-            return await self.async_step_auth()
+            return await self.async_step_auth_method()
 
         current_addresses = self._async_current_ids()
         for discovery_info in async_discovered_service_info(self.hass):
@@ -171,10 +170,42 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_auth(
+    async def async_step_auth_method(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Get auth key."""
+        if user_input is not None:
+            auth_method = user_input.get(CONF_AUTH_METHOD)
+
+            if auth_method == AUTH_MANUAL:
+                return await self.async_step_auth_manual()
+
+            elif auth_method == AUTH_FETCH:
+                return await self.async_step_auth_fetch()
+
+            elif auth_method == NO_AUTH:
+                return self.async_create_entry(
+                    title=self.context["title_placeholders"]["name"],
+                )
+
+        return self.async_show_form(
+            step_id="auth_method",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_AUTH_METHOD, default=AUTH_FETCH): vol.In(
+                        (
+                            AUTH_FETCH,
+                            AUTH_MANUAL,
+                            NO_AUTH,
+                        )
+                    )
+                }),
+        )
+
+    async def async_step_auth_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Write auth key."""
         errors = {}
         if user_input is not None:
             auth_key = user_input.get(CONF_AUTH_KEY)
@@ -192,11 +223,52 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="auth",
+            step_id="auth_manual",
             description_placeholders=self.context["title_placeholders"],
             data_schema=vol.Schema({vol.Optional(CONF_AUTH_KEY): str}),
             errors=errors,
         )
+
+    async def async_step_auth_fetch(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Fetc auth key."""
+        errors = {}
+        code = None
+        try:
+            await self._discovered_device.device.connect(timeout=30.0)
+            code = await self._discovered_device.device.fetch_authentication_code()
+            code = validated_authentication_code(code)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug(err)
+            errors["base"] = err
+        finally:
+            await self._discovered_device.device.disconnect()
+
+        if code == None:
+            _LOGGER.error(
+                "Code was empty",
+            )
+            # TODO: Show retry button
+            return await self.async_step_auth_method()
+
+        elif code == bytearray(b'\x00\x00\x00\x00'):
+            _LOGGER.error(
+                "Code was only 0: %s",
+                code,
+            )
+            # TODO: Show retry button
+            return await self.async_step_auth_method()
+
+        else:
+            _LOGGER.error(
+                "Code was: %s",
+                code,
+            )
+            return self.async_create_entry(
+                title=self.context["title_placeholders"]["name"],
+                data={CONF_AUTH_KEY: code},
+            )
 
     @staticmethod
     @callback

--- a/custom_components/fresh_intellivent_sky/const.py
+++ b/custom_components/fresh_intellivent_sky/const.py
@@ -8,6 +8,11 @@ DISPATCH_DETECTION = f"{DOMAIN}.detection"
 
 DEFAULT_SCAN_INTERVAL = 120
 
+AUTH_MANUAL = "auth_manual"
+AUTH_FETCH = "auth_fetch"
+NO_AUTH = "no_auth"
+
+CONF_AUTH_METHOD = "auth_method"
 CONF_AUTH_KEY = "auth_key"
 CONF_SCAN_INTERVAL = "scan_interval"
 

--- a/custom_components/fresh_intellivent_sky/strings.json
+++ b/custom_components/fresh_intellivent_sky/strings.json
@@ -5,11 +5,20 @@
       "user": {
         "description": "Select device"
       },
-      "auth": {
+      "auth_method": {
+        "description": "To be able to update values you need to provide an auth key.",
+        "data": {
+          "auth_method": "Choose between manually entering auth key or automatically fetching it from the fan."
+        }
+      },
+      "auth_manual": {
         "description": "To be able to update values you need to provide an auth key.",
         "data": {
           "auth_key": "Auth key"
         }
+      },
+      "auth_fetch": {
+        "description": "Press power + WiFi buttons on the fan for 8 seconds until it starts to flash and press next.",
       },
       "bluetooth_confirm": {
         "description": "Bluetooth Confirm Description"


### PR DESCRIPTION
🚨 TODOs before merging this:
- [ ] Add translation strings (shows variable names now)
- [ ] Better error handling for fetching authentication code
- [ ] Need [this PR](https://github.com/LaStrada/pyfreshintellivent/pull/30) from [pyfreshintellivent](https://github.com/LaStrada/pyfreshintellivent) (has a small breaking change)

This PR implements a new config flow:
* Manual input (already supported)
* No code (already supported, but before you had to leave an empty string when asked for auth code)
* Automatically fetch auth code (new)