### PR TITLE
Fix timer delay

### DIFF
--- a/custom_components/fresh_intellivent_sky/number.py
+++ b/custom_components/fresh_intellivent_sky/number.py
@@ -134,9 +134,9 @@ async def async_setup_entry(
                 NumberEntityDescription(
                     key="timer_delay_minutes",
                     name="Timer delay minutes",
-                    native_min_value=1,
-                    native_max_value=60,
-                    native_step=4,
+                    native_min_value=0,
+                    native_max_value=10,
+                    native_step=1,
                     native_unit_of_measurement=UnitOfTime.MINUTES,
                 ),
                 entity_category=EntityCategory.CONFIG,

--- a/custom_components/fresh_intellivent_sky/number.py
+++ b/custom_components/fresh_intellivent_sky/number.py
@@ -251,7 +251,7 @@ class FreshIntelliventSkyNumber(
                 RPM_KEY: self.device.modes["timer"][RPM_KEY],
             }
         elif key == "timer_delay_minutes":
-            delay_minutes = int(self.device.modes["timer"][RPM_KEY])
+            delay_minutes = int(value)
             delay_enabled = delay_minutes > 0
 
             self.coordinator.hass.data[TIMER_MODE_UPDATE] = {


### PR DESCRIPTION
It never used the new value for `delay minutes`, but instead used `rpm`. This was a 2 bytes value and not 1 byte value which was expected and caused this error:
```
Error fetching fresh_intellivent_sky data: Unable to fetch data: ubyte format requires 0 <= number <= 255
```

Also adjusted the accepted range for `delay minutes´, it supports up to 10 minutes. Everything above this is just set to 10 again.