### PR TITLE
Fix config flow `no_auth`

### DIFF
--- a/custom_components/fresh_intellivent_sky/config_flow.py
+++ b/custom_components/fresh_intellivent_sky/config_flow.py
@@ -203,6 +203,7 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
         """No auth key."""
         return self.async_create_entry(
             title=self.context["title_placeholders"]["name"],
+            data={},
         )
 
     async def async_step_auth_manual(

--- a/custom_components/fresh_intellivent_sky/config_flow.py
+++ b/custom_components/fresh_intellivent_sky/config_flow.py
@@ -22,7 +22,6 @@ from voluptuous.validators import All, Range
 
 from .const import (
     CONF_AUTH_KEY,
-    CONF_AUTH_METHOD,
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,

--- a/custom_components/fresh_intellivent_sky/config_flow.py
+++ b/custom_components/fresh_intellivent_sky/config_flow.py
@@ -193,21 +193,16 @@ class FreshIntelliventSkyConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="auth_method", errors=errors, last_step=False
             )
-        if user_input is not None:
-            auth_method = user_input.get(CONF_AUTH_METHOD)
-
-            if auth_method == AUTH_MANUAL:
-                return await self.async_step_auth_manual()
-
-            elif auth_method == AUTH_FETCH:
-                return await self.async_step_auth_fetch()
-
-            elif auth_method == NO_AUTH:
-                return self.async_create_entry(
-                    title=self.context["title_placeholders"]["name"],
-                )
         return self.async_show_menu(
             step_id="auth_method", menu_options=[AUTH_FETCH, AUTH_MANUAL, NO_AUTH]
+        )
+
+    async def async_step_no_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """No auth key."""
+        return self.async_create_entry(
+            title=self.context["title_placeholders"]["name"],
         )
 
     async def async_step_auth_manual(

--- a/custom_components/fresh_intellivent_sky/const.py
+++ b/custom_components/fresh_intellivent_sky/const.py
@@ -14,7 +14,6 @@ NO_AUTH = "no_auth"
 AUTH_CODE_ONLY_ZERO = "auth_code_only_zero"
 AUTH_CODE_EMPTY = "auth_code_empty"
 
-CONF_AUTH_METHOD = "auth_method"
 CONF_AUTH_KEY = "auth_key"
 CONF_SCAN_INTERVAL = "scan_interval"
 


### PR DESCRIPTION
When selecting an option (`AUTH_FETCH`, `AUTH_MANUAL` or `NO_AUTH`) it automatically jumps to `async_step_<step>` and will never execute the old code to check what the user selected.

The error I got:
```
ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/Users/stale/private_projects/ha/core/venv/lib/python3.10/site-packages/aiohttp/web_protocol.py", line 435, in _handle_request
    resp = await request_handler(request)
  File "/Users/stale/private_projects/ha/core/venv/lib/python3.10/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/Users/stale/private_projects/ha/core/venv/lib/python3.10/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/forwarded.py", line 100, in forwarded_middleware
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/ban.py", line 80, in ban_middleware
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/auth.py", line 236, in auth_middleware
    return await handler(request)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/view.py", line 136, in handle
    result = await result
  File "/Users/stale/private_projects/ha/core/homeassistant/components/config/config_entries.py", line 180, in post
    return await super().post(request, flow_id)
  File "/Users/stale/private_projects/ha/core/homeassistant/components/http/data_validator.py", line 72, in wrapper
    result = await method(view, request, data, *args, **kwargs)
  File "/Users/stale/private_projects/ha/core/homeassistant/helpers/data_entry_flow.py", line 110, in post
    result = await self._flow_mgr.async_configure(flow_id, data)
  File "/Users/stale/private_projects/ha/core/homeassistant/data_entry_flow.py", line 249, in async_configure
    result = await self._async_handle_step(
  File "/Users/stale/private_projects/ha/core/homeassistant/data_entry_flow.py", line 330, in _async_handle_step
    raise UnknownStep(
homeassistant.data_entry_flow.UnknownStep: Handler FreshIntelliventSkyConfigFlow doesn't support step no_auth
```