### PR TITLE
Fix detection mode == off

### DIFF
--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -150,7 +150,9 @@ class FreshIntelliventSkySelect(
 
         if key == "humidity_detection":
             humidity = self.device.modes["humidity"]
-            detection = self._detection_off_check(new_value=option, previous_value=humidity[DETECTION_KEY])
+            detection = self._detection_off_check(
+                new_value=option, previous_value=humidity[DETECTION_KEY]
+            )
 
             self.coordinator.hass.data[HUMIDITY_MODE_UPDATE] = {
                 "enabled": enabled,
@@ -169,14 +171,12 @@ class FreshIntelliventSkySelect(
             if key == "light_detection":
                 light_enabled = enabled
                 light_detection = self._detection_off_check(
-                    new_value=option,
-                    previous_value=light_detection
+                    new_value=option, previous_value=light_detection
                 )
             else:
                 voc_enabled = enabled
                 voc_detection = self._detection_off_check(
-                    new_value=option,
-                    previous_value=voc_detection
+                    new_value=option, previous_value=voc_detection
                 )
 
             self.coordinator.hass.data[LIGHT_AND_VOC_MODE_UPDATE] = {

--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -142,8 +142,8 @@ class FreshIntelliventSkySelect(
             }
         else:
             light = self.device.modes["light_and_voc"]["light"]
-            light_enabled = light["enabled"]
             light_detection = light["detection"]
+            light_enabled = light["enabled"]
 
             voc = self.device.modes["light_and_voc"]["voc"]
             voc_enabled = voc["enabled"]
@@ -151,10 +151,18 @@ class FreshIntelliventSkySelect(
 
             if self.entity_description.key == "light_detection":
                 light_enabled = enabled
-                light_detection = option
+
+                # Detection `off` is not supported. Use `enabled=false` instead.
+                # We can reuse the last option to fix this.
+                if option != DETECTION_OFF:
+                    light_detection = option
             else:
                 voc_enabled = enabled
-                voc_detection = option
+
+                # Detection `off` is not supported. Use `enabled=false` instead.
+                # We can reuse the last option to fix this.
+                if option != DETECTION_OFF:
+                    voc_detection = option
 
             self.coordinator.hass.data[LIGHT_AND_VOC_MODE_UPDATE] = {
                 "light_enabled": light_enabled,

--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -22,6 +22,7 @@ from .const import (
     HUMIDITY_MODE_UPDATE,
     LIGHT_AND_VOC_MODE_UPDATE,
     DETECTION_KEY,
+    ENABLED_KEY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -143,12 +144,12 @@ class FreshIntelliventSkySelect(
             }
         else:
             light = self.device.modes["light_and_voc"]["light"]
-            light_detection = light["detection"]
-            light_enabled = light["enabled"]
+            light_enabled = light[ENABLED_KEY]
+            light_detection = light[DETECTION_KEY]
 
             voc = self.device.modes["light_and_voc"]["voc"]
-            voc_enabled = voc["enabled"]
-            voc_detection = voc["detection"]
+            voc_enabled = voc[ENABLED_KEY]
+            voc_detection = voc[DETECTION_KEY]
 
             if key == "light_detection":
                 light_enabled = enabled

--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -21,6 +21,7 @@ from .const import (
     DOMAIN,
     HUMIDITY_MODE_UPDATE,
     LIGHT_AND_VOC_MODE_UPDATE,
+    DETECTION_KEY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ async def async_setup_entry(
                     key="humidity_detection",
                     name="Humidity detection",
                 ),
-                keys=["humidity", "detection"],
+                keys=["humidity", DETECTION_KEY],
             ),
             FreshIntelliventSkySelect(
                 coordinator,
@@ -54,7 +55,7 @@ async def async_setup_entry(
                     key="light_detection",
                     name="Light detection",
                 ),
-                keys=["light_and_voc", "light", "detection"],
+                keys=["light_and_voc", "light", DETECTION_KEY],
             ),
             FreshIntelliventSkySelect(
                 coordinator,
@@ -63,7 +64,7 @@ async def async_setup_entry(
                     key="voc_detection",
                     name="VOC detection",
                 ),
-                keys=["light_and_voc", "voc", "detection"],
+                keys=["light_and_voc", "voc", DETECTION_KEY],
             ),
         ]
     )

--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -133,8 +133,9 @@ class FreshIntelliventSkySelect(
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         enabled = option == DETECTION_OFF
+        key = self.entity_description.key
 
-        if self.entity_description.key == "humidity_detection":
+        if key == "humidity_detection":
             self.coordinator.hass.data[HUMIDITY_MODE_UPDATE] = {
                 "enabled": enabled,
                 "detection": option,
@@ -149,7 +150,7 @@ class FreshIntelliventSkySelect(
             voc_enabled = voc["enabled"]
             voc_detection = voc["detection"]
 
-            if self.entity_description.key == "light_detection":
+            if key == "light_detection":
                 light_enabled = enabled
 
                 # Detection `off` is not supported. Use `enabled=false` instead.


### PR DESCRIPTION
Setting any detections to `off` failed because `pyfreshintellivent` doesn't support it. `Off` actually means that `enabled=true` and `detection` is ignored.

Solution:
* If new detection mode equals `off`:
  * Ignore it and use previous value
  * Set `enabled=false`
* If new detection mode does not equals `off`:
  * Use new value
  * Set `enabled=true`

This applies to light, voc and humidity. Also refactored a bit to reuse available constants.