### PR TITLE
Remove old debug code

### DIFF
--- a/custom_components/fresh_intellivent_sky/select.py
+++ b/custom_components/fresh_intellivent_sky/select.py
@@ -138,7 +138,6 @@ class FreshIntelliventSkySelect(
     def _detection_off_check(self, new_value: str, previous_value: str) -> str:
         """Detection `off` is not supported. Use `enabled=false` instead.
         # We can reuse the last option to fix this."""
-        _LOGGER.debug("new_value: %s, previous_value: %s", new_value, previous_value)
         if new_value != DETECTION_OFF:
             return new_value
         return previous_value


### PR DESCRIPTION
Just forgot to remove a debug logger when I tested the `detection=off` issue. Doesn't give any value to the user by having it here.