### PR TITLE
Update name (hacs.json)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Fresh Intellivent Sky Integration (BLE)",
+  "name": "Fresh Intellivent Sky (BLE)",
   "render_readme": true
 }


### PR DESCRIPTION
On smaller screens (phones) sometime there is not enough space for the full name. For example my old iPhone SE 1st gen. It is not very common, as far as I know, to use "integration" in the name, so I think we can safely remove it without confusing anyone.