### PR TITLE
No device error handling

### DIFF
--- a/custom_components/fresh_intellivent_sky/__init__.py
+++ b/custom_components/fresh_intellivent_sky/__init__.py
@@ -50,8 +50,6 @@ READ_ONLY_PLATFORMS = [
     Platform.SENSOR,
 ]
 
-MAX_ATTEMPTS = 5
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/fresh_intellivent_sky/__init__.py
+++ b/custom_components/fresh_intellivent_sky/__init__.py
@@ -91,7 +91,7 @@ async def async_setup_entry(
         ble_device = bluetooth.async_ble_device_from_address(hass, address)
 
         if not ble_device:
-            raise UpdateFailed(f"Unable to find device: {err}") from err
+            raise UpdateFailed(f"Unable to find device: {address}")
 
         client = FreshIntelliVent(ble_device=ble_device)
 

--- a/custom_components/fresh_intellivent_sky/__init__.py
+++ b/custom_components/fresh_intellivent_sky/__init__.py
@@ -69,6 +69,9 @@ async def async_setup_entry(
         hass.data[update] = None
 
     ble_device = bluetooth.async_ble_device_from_address(hass, address)
+    if ble_device is None:
+        return False
+
     auth_key = entry.data.get(CONF_AUTH_KEY)
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL)
 
@@ -83,6 +86,9 @@ async def async_setup_entry(
     async def _async_update_method():
         """Get data from Fresh Intellivent Sky."""
         ble_device = bluetooth.async_ble_device_from_address(hass, address)
+        if ble_device is None:
+            return False
+
         client = FreshIntelliVent(ble_device=ble_device)
 
         error = None

--- a/custom_components/fresh_intellivent_sky/__init__.py
+++ b/custom_components/fresh_intellivent_sky/__init__.py
@@ -69,8 +69,11 @@ async def async_setup_entry(
         hass.data[update] = None
 
     ble_device = bluetooth.async_ble_device_from_address(hass, address)
-    if ble_device is None:
-        return False
+
+    if not ble_device:
+        raise ConfigEntryNotReady(
+            f"Could not find Fresh Intellivent Sky device with address {address}"
+        )
 
     auth_key = entry.data.get(CONF_AUTH_KEY)
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL)
@@ -86,8 +89,9 @@ async def async_setup_entry(
     async def _async_update_method():
         """Get data from Fresh Intellivent Sky."""
         ble_device = bluetooth.async_ble_device_from_address(hass, address)
-        if ble_device is None:
-            return False
+
+        if not ble_device:
+            raise UpdateFailed(f"Unable to find device: {err}") from err
 
         client = FreshIntelliVent(ble_device=ble_device)
 
@@ -109,7 +113,7 @@ async def async_setup_entry(
         try:
             await client.disconnect()
         except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.info(
+            _LOGGER.error(
                 "Couldn't disconnect",
                 address,
                 err,


### PR DESCRIPTION
I suddenly got a few errors. If HA cannot find the BLE device it can fail, and will never be able to recover unless you restart HA.

Example of error:

```
2023-02-04 09:52:35.478 ERROR (MainThread) [custom_components.fresh_intellivent_sky] Unexpected error fetching fresh_intellivent_sky data: 'NoneType' object has no attribute 'address'
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 239, in _async_refresh
File "/config/custom_components/fresh_intellivent_sky/__init__.py", line 86, in _async_update_method
client = FreshIntelliVent(ble_device=ble_device)
File "/usr/local/lib/python3.10/site-packages/pyfreshintellivent/__init__.py", line 23, in __init__
2023-02-04 09:52:35.484 DEBUG (MainThread) [custom_components.fresh_intellivent_sky] Finished fetching fresh_intellivent_sky data in 0.007 seconds (success: False) 
```