### PR TITLE
Bump lib to latest version

### DIFF
--- a/custom_components/fresh_intellivent_sky/manifest.json
+++ b/custom_components/fresh_intellivent_sky/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fresh Intellivent Sky",
   "config_flow": true,
   "documentation": "https://github.com/angoyd/freshintelliventHacs",
-  "requirements": ["pyfreshintellivent==0.3.1"],
+  "requirements": ["pyfreshintellivent==0.3.3"],
   "codeowners": ["@LaStrada", "@angoyd"],
   "iot_class": "local_polling",
   "loggers": ["bleak", "pyfreshintellivent"],


### PR DESCRIPTION
This should fix #46.

<ins>**Please test**</ins> before merging, I don't have much time as we speak. Will be more available in about 2 weeks.

Diff:
https://github.com/LaStrada/pyfreshintellivent/compare/v0.3.1...v0.3.3

There will be another release a bit later:

* ~~Need to update dependencies etc. (officially support Python 3.13, matching HA's dependencies).~~
* And after that I would like to finish rewriting the whole framework to match other official BLE integrations/frameworks.
* Also need a fix for the issue with not able to update settings.