### PR TITLE
Bump minimum HA version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Fresh Intellivent Sky (BLE)",
   "render_readme": true,
-  "homeassistant": "2025.5.0"
+  "homeassistant": "2025.8.0"
 }


### PR DESCRIPTION
Since Home Assistant 2025.8 updated some libraries, and we are updating the `pyfreshintellivent` framework (see #50), I think it’s a good idea to bump the minimum HA version to 2025.8 just in case this breaks older versions of HA.
